### PR TITLE
내 정보 조회 API 를 추가합니다

### DIFF
--- a/src/main/java/com/depromeet/todo/application/BadRequestException.java
+++ b/src/main/java/com/depromeet/todo/application/BadRequestException.java
@@ -1,0 +1,15 @@
+package com.depromeet.todo.application;
+
+import org.springframework.lang.Nullable;
+
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(String message) {
+        super(message);
+    }
+
+    public static void nonNull(@Nullable Object object, String message) {
+        if (object == null) {
+            throw new BadRequestException(message);
+        }
+    }
+}

--- a/src/main/java/com/depromeet/todo/application/ResourceNotFoundException.java
+++ b/src/main/java/com/depromeet/todo/application/ResourceNotFoundException.java
@@ -1,0 +1,7 @@
+package com.depromeet.todo.application;
+
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/depromeet/todo/application/member/DisplayableMemberAssembler.java
+++ b/src/main/java/com/depromeet/todo/application/member/DisplayableMemberAssembler.java
@@ -1,0 +1,8 @@
+package com.depromeet.todo.application.member;
+
+import com.depromeet.todo.application.Displayable;
+import com.depromeet.todo.domain.member.Member;
+
+public interface DisplayableMemberAssembler {
+    Displayable toDisplayableMember(Member member);
+}

--- a/src/main/java/com/depromeet/todo/application/member/MemberService.java
+++ b/src/main/java/com/depromeet/todo/application/member/MemberService.java
@@ -1,5 +1,7 @@
 package com.depromeet.todo.application.member;
 
+import com.depromeet.todo.application.BadRequestException;
+import com.depromeet.todo.application.ResourceNotFoundException;
 import com.depromeet.todo.domain.IdGenerator;
 import com.depromeet.todo.domain.member.Member;
 import com.depromeet.todo.domain.member.MemberRepository;
@@ -30,5 +32,13 @@ public class MemberService {
                     Member member = Member.of(snowFlakeIdGenerator, oAuthUserInfo);
                     return memberRepository.save(member);
                 });
+    }
+
+    @Transactional(readOnly = true)
+    public Member getMember(Long memberId) {
+        BadRequestException.nonNull(memberId, "'memberId' must not be null");
+
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new ResourceNotFoundException("Member not found. memberId:" + memberId));
     }
 }

--- a/src/main/java/com/depromeet/todo/infrastructure/kma/KmaApiBodyItems.java
+++ b/src/main/java/com/depromeet/todo/infrastructure/kma/KmaApiBodyItems.java
@@ -13,7 +13,7 @@ public class KmaApiBodyItems<T extends KmaApiWeatherItem> {
     @JsonProperty("item")
     private List<T> itemList;
 
-    // XXX: items: "" 로 들어오는 경우에 대한 방어코드
+    @SuppressWarnings("squid:S1172")    // XXX: items: "" 로 들어오는 경우에 대한 방어코드
     public KmaApiBodyItems(String input) {
         this.itemList = Collections.emptyList();
     }

--- a/src/main/java/com/depromeet/todo/infrastructure/spring/security/HttpBodyAuthenticationProvider.java
+++ b/src/main/java/com/depromeet/todo/infrastructure/spring/security/HttpBodyAuthenticationProvider.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.util.StringUtils;
@@ -14,7 +13,7 @@ public class HttpBodyAuthenticationProvider implements AuthenticationProvider {
     private final UserDetailsService todoUserDetailsService;
 
     @Override
-    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+    public Authentication authenticate(Authentication authentication) {
         if (!this.supports(authentication.getClass())) {
             return null;
         }

--- a/src/main/java/com/depromeet/todo/infrastructure/spring/security/HttpPostAuthenticationProcessingFilter.java
+++ b/src/main/java/com/depromeet/todo/infrastructure/spring/security/HttpPostAuthenticationProcessingFilter.java
@@ -12,7 +12,6 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -47,7 +46,7 @@ public class HttpPostAuthenticationProcessingFilter extends AbstractAuthenticati
      * @throws AuthenticationException if authentication fails.
      */
     @Override
-    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) {
         MediaType mediaType = this.resolveMediaType(request);
         if (!MediaType.APPLICATION_JSON.isCompatibleWith(mediaType)) {
             return null;

--- a/src/main/java/com/depromeet/todo/infrastructure/spring/security/HttpPostAuthenticationProcessingFilter.java
+++ b/src/main/java/com/depromeet/todo/infrastructure/spring/security/HttpPostAuthenticationProcessingFilter.java
@@ -47,7 +47,7 @@ public class HttpPostAuthenticationProcessingFilter extends AbstractAuthenticati
      * @throws AuthenticationException if authentication fails.
      */
     @Override
-    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException, IOException, ServletException {
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
         MediaType mediaType = this.resolveMediaType(request);
         if (!MediaType.APPLICATION_JSON.isCompatibleWith(mediaType)) {
             return null;

--- a/src/main/java/com/depromeet/todo/infrastructure/spring/security/JsonAccessDeniedHandler.java
+++ b/src/main/java/com/depromeet/todo/infrastructure/spring/security/JsonAccessDeniedHandler.java
@@ -7,7 +7,6 @@ import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -19,7 +18,7 @@ public class JsonAccessDeniedHandler implements AccessDeniedHandler {
     @Override
     public void handle(HttpServletRequest request,
                        HttpServletResponse response,
-                       AccessDeniedException accessDeniedException) throws IOException, ServletException {
+                       AccessDeniedException accessDeniedException) throws IOException {
         response.setStatus(HttpStatus.FORBIDDEN.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         writeObjectMapper.writeValue(

--- a/src/main/java/com/depromeet/todo/infrastructure/spring/security/JsonAuthenticationEntryPoint.java
+++ b/src/main/java/com/depromeet/todo/infrastructure/spring/security/JsonAuthenticationEntryPoint.java
@@ -8,7 +8,6 @@ import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -20,7 +19,7 @@ public class JsonAuthenticationEntryPoint implements AuthenticationEntryPoint {
     @Override
     public void commence(HttpServletRequest request,
                          HttpServletResponse response,
-                         AuthenticationException authException) throws IOException, ServletException {
+                         AuthenticationException authException) throws IOException {
         response.setStatus(HttpStatus.UNAUTHORIZED.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         writeObjectMapper.writeValue(

--- a/src/main/java/com/depromeet/todo/infrastructure/spring/security/JsonAuthenticationFailureHandler.java
+++ b/src/main/java/com/depromeet/todo/infrastructure/spring/security/JsonAuthenticationFailureHandler.java
@@ -9,7 +9,6 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -19,7 +18,7 @@ public class JsonAuthenticationFailureHandler implements AuthenticationFailureHa
     private final ObjectMapper writeObjectMapper;
 
     @Override
-    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException {
         response.setStatus(HttpStatus.UNAUTHORIZED.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         writeObjectMapper.writeValue(

--- a/src/main/java/com/depromeet/todo/infrastructure/spring/security/JsonAuthenticationSuccessHandler.java
+++ b/src/main/java/com/depromeet/todo/infrastructure/spring/security/JsonAuthenticationSuccessHandler.java
@@ -11,7 +11,6 @@ import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -25,7 +24,7 @@ public class JsonAuthenticationSuccessHandler implements AuthenticationSuccessHa
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request,
                                         HttpServletResponse response,
-                                        Authentication authentication) throws IOException, ServletException {
+                                        Authentication authentication) throws IOException {
 
         TodoAuthenticationToken todoAuthenticationToken = (TodoAuthenticationToken) authentication;
         String accessToken = tokenService.generate(

--- a/src/main/java/com/depromeet/todo/infrastructure/spring/security/JsonLogoutSuccessHandler.java
+++ b/src/main/java/com/depromeet/todo/infrastructure/spring/security/JsonLogoutSuccessHandler.java
@@ -6,10 +6,8 @@ import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
 
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
 
 @RequiredArgsConstructor
 public class JsonLogoutSuccessHandler implements LogoutSuccessHandler {
@@ -17,7 +15,7 @@ public class JsonLogoutSuccessHandler implements LogoutSuccessHandler {
     @Override
     public void onLogoutSuccess(HttpServletRequest request,
                                 HttpServletResponse response,
-                                Authentication authentication) throws IOException, ServletException {
+                                Authentication authentication) {
         response.setStatus(HttpStatus.NO_CONTENT.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
     }

--- a/src/main/java/com/depromeet/todo/infrastructure/spring/security/PreAuthTokenAuthenticationProvider.java
+++ b/src/main/java/com/depromeet/todo/infrastructure/spring/security/PreAuthTokenAuthenticationProvider.java
@@ -4,7 +4,6 @@ import com.depromeet.todo.application.security.TokenService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 
 import java.util.Optional;
@@ -14,7 +13,7 @@ public class PreAuthTokenAuthenticationProvider implements AuthenticationProvide
     private final TokenService<Long> tokenService;
 
     @Override
-    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+    public Authentication authenticate(Authentication authentication) {
         if (!this.supports(authentication.getClass())) {
             return null;
         }

--- a/src/main/java/com/depromeet/todo/presentation/common/ApiControllerAdvice.java
+++ b/src/main/java/com/depromeet/todo/presentation/common/ApiControllerAdvice.java
@@ -1,17 +1,30 @@
 package com.depromeet.todo.presentation.common;
 
 import com.depromeet.todo.application.ExternalServiceException;
+import com.depromeet.todo.infrastructure.spring.security.TodoAuthenticationToken;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.security.Principal;
 
 @Slf4j
 @RestControllerAdvice
 public class ApiControllerAdvice {
+
+    @ModelAttribute("memberId")
+    public Long resolveMemberId(Principal principal) {
+        if (principal instanceof TodoAuthenticationToken) {
+            return ((TodoAuthenticationToken) principal).getMemberId();
+        }
+        return null;
+    }
+
     /**
      * 사용자 요청에 오류가 있는 경우
      */

--- a/src/main/java/com/depromeet/todo/presentation/common/ApiResponse.java
+++ b/src/main/java/com/depromeet/todo/presentation/common/ApiResponse.java
@@ -28,7 +28,7 @@ public interface ApiResponse<T> {
         return new SuccessSimpleResponse<>(data);
     }
 
-    static ApiResponse failureFrom(String message) {
+    static ApiResponse<String> failureFrom(String message) {
         return new FailureResponse(message, null);
     }
 }

--- a/src/main/java/com/depromeet/todo/presentation/common/FailureResponse.java
+++ b/src/main/java/com/depromeet/todo/presentation/common/FailureResponse.java
@@ -5,14 +5,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Data
-@EqualsAndHashCode(callSuper = false)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
-class FailureResponse implements ApiResponse {
+public class FailureResponse implements ApiResponse<String> {
     private String message;
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @JsonProperty("errors")

--- a/src/main/java/com/depromeet/todo/presentation/common/SuccessListResponse.java
+++ b/src/main/java/com/depromeet/todo/presentation/common/SuccessListResponse.java
@@ -1,10 +1,15 @@
 package com.depromeet.todo.presentation.common;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Data
-class SuccessListResponse<T> implements ApiResponse<T> {
-    private final List<T> data;
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
+public class SuccessListResponse<T> implements ApiResponse<T> {
+    private List<T> data;
 }

--- a/src/main/java/com/depromeet/todo/presentation/common/SuccessPageResponse.java
+++ b/src/main/java/com/depromeet/todo/presentation/common/SuccessPageResponse.java
@@ -1,11 +1,16 @@
 package com.depromeet.todo.presentation.common;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Data
-class SuccessPageResponse<T> implements ApiResponse<T> {
-    private final List<T> data;
-    private final Long totalCount;
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
+public class SuccessPageResponse<T> implements ApiResponse<T> {
+    private List<T> data;
+    private Long totalCount;
 }

--- a/src/main/java/com/depromeet/todo/presentation/common/SuccessSimpleResponse.java
+++ b/src/main/java/com/depromeet/todo/presentation/common/SuccessSimpleResponse.java
@@ -1,8 +1,13 @@
 package com.depromeet.todo.presentation.common;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
-class SuccessSimpleResponse<T> implements ApiResponse<T> {
-    private final T data;
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
+public class SuccessSimpleResponse<T> implements ApiResponse<T> {
+    private T data;
 }

--- a/src/main/java/com/depromeet/todo/presentation/common/SuccessSliceResponse.java
+++ b/src/main/java/com/depromeet/todo/presentation/common/SuccessSliceResponse.java
@@ -1,11 +1,16 @@
 package com.depromeet.todo.presentation.common;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Data
-class SuccessSliceResponse<T> implements ApiResponse<T> {
-    private final List<T> data;
-    private final Boolean hasNext;
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
+public class SuccessSliceResponse<T> implements ApiResponse<T> {
+    private List<T> data;
+    private Boolean hasNext;
 }

--- a/src/main/java/com/depromeet/todo/presentation/member/MemberController.java
+++ b/src/main/java/com/depromeet/todo/presentation/member/MemberController.java
@@ -1,0 +1,25 @@
+package com.depromeet.todo.presentation.member;
+
+import com.depromeet.todo.application.member.MemberService;
+import com.depromeet.todo.domain.member.Member;
+import com.depromeet.todo.presentation.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class MemberController {
+    private final MemberService memberService;
+    private final MemberResponseAssembler memberResponseAssembler;
+
+    @GetMapping("/members/me")
+    public ApiResponse<MemberResponse> getMe(@ModelAttribute("memberId") Long memberId) {
+        Member member = memberService.getMember(memberId);
+        MemberResponse memberResponse = memberResponseAssembler.toDisplayableMember(member);
+        return ApiResponse.successFrom(memberResponse);
+    }
+}

--- a/src/main/java/com/depromeet/todo/presentation/member/MemberResponse.java
+++ b/src/main/java/com/depromeet/todo/presentation/member/MemberResponse.java
@@ -1,0 +1,19 @@
+package com.depromeet.todo.presentation.member;
+
+import com.depromeet.todo.application.Displayable;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class MemberResponse implements Displayable {
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    private Long id;
+    private String providerType;
+    private String providerUserId;
+    //    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
+    private LocalDateTime createdAt;
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/depromeet/todo/presentation/member/MemberResponseAssembler.java
+++ b/src/main/java/com/depromeet/todo/presentation/member/MemberResponseAssembler.java
@@ -1,0 +1,22 @@
+package com.depromeet.todo.presentation.member;
+
+import com.depromeet.todo.application.member.DisplayableMemberAssembler;
+import com.depromeet.todo.domain.member.Member;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MemberResponseAssembler implements DisplayableMemberAssembler {
+    @Override
+    public MemberResponse toDisplayableMember(Member member) {
+        if (member == null) {
+            return null;
+        }
+        MemberResponse memberResponse = new MemberResponse();
+        memberResponse.setId(member.getMemberId());
+        memberResponse.setProviderType(member.getOauthUserInfo().getProviderType().name());
+        memberResponse.setProviderUserId(member.getOauthUserInfo().getProviderUserId());
+        memberResponse.setCreatedAt(member.getCreatedAt());
+        memberResponse.setUpdatedAt(member.getUpdatedAt());
+        return memberResponse;
+    }
+}

--- a/src/test/java/com/depromeet/todo/TodoApplicationTests.java
+++ b/src/test/java/com/depromeet/todo/TodoApplicationTests.java
@@ -6,6 +6,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class TodoApplicationTests {
 
+	@SuppressWarnings("EmptyMethod")
 	@Test
 	void contextLoads() {
 	}

--- a/src/test/java/com/depromeet/todo/infrastructure/jwt/JwtServiceTest.java
+++ b/src/test/java/com/depromeet/todo/infrastructure/jwt/JwtServiceTest.java
@@ -19,19 +19,14 @@ class JwtServiceTest {
                 "TOKEN_ISSUER",
                 "TOKEN_SIGNING_KEY"
         );
-        tokenService.init();
-
         anotherIssuerJwtService = new JwtService(
                 "ANOTHER_TOKEN_ISSUER",
                 "TOKEN_SIGNING_KEY"
         );
-        anotherIssuerJwtService.init();
-
         anotherSigningKeyJwtService = new JwtService(
                 "TOKEN_ISSUER",
                 "ANOTHER_TOKEN_SINGING_KEY"
         );
-        anotherSigningKeyJwtService.init();
     }
 
     @Test
@@ -53,7 +48,6 @@ class JwtServiceTest {
     void token_issuer_는_값이_달라도_decode_성공해야함() {
         // given
         Long memberId = 1L;
-
         String tokenByAnotherSigningKey = anotherIssuerJwtService.generate(memberId);
         assertThat(tokenByAnotherSigningKey).isNotBlank();
         // when
@@ -66,7 +60,6 @@ class JwtServiceTest {
     void signing_key_가_다른_경우_decode_실패해야함() {
         // given
         Long memberId = 1L;
-
         String tokenByAnotherSigningKey = anotherSigningKeyJwtService.generate(memberId);
         assertThat(tokenByAnotherSigningKey).isNotBlank();
         // when

--- a/src/test/java/com/depromeet/todo/integration/LoginTest.java
+++ b/src/test/java/com/depromeet/todo/integration/LoginTest.java
@@ -1,0 +1,87 @@
+package com.depromeet.todo.integration;
+
+import com.depromeet.todo.domain.member.oauth.OAuthService;
+import com.depromeet.todo.domain.member.oauth.OAuthUserInfo;
+import com.depromeet.todo.integration.api.MemberApi;
+import com.depromeet.todo.integration.api.TestApiResult;
+import com.depromeet.todo.presentation.common.SuccessSimpleResponse;
+import com.depromeet.todo.presentation.member.LoginResponse;
+import com.depromeet.todo.presentation.member.MemberResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+@SuppressWarnings("NonAsciiCharacters")
+@Transactional
+@SpringBootTest
+public class LoginTest {
+    @MockBean
+    private OAuthService kakaoUserService;
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private MemberApi memberApi;
+
+    @BeforeEach
+    void setUp() {
+        memberApi = new MemberApi(mockMvc, objectMapper);
+    }
+
+    @Test
+    void 로그인_후_accessToken_으로_인증이_필요한_API_요청시_성공() throws Exception {
+        // given
+        when(kakaoUserService.getUserInfo(any())).thenReturn(OAuthUserInfo.fromKakao("providerUserId"));
+        // when,then 1
+        String accessToken = this.로그인("kakaoAccessToken");
+        // when,then 2
+        this.내_정보_조회(accessToken);
+    }
+
+    private String 로그인(String accessToken) throws Exception {
+        TestApiResult<SuccessSimpleResponse<LoginResponse>> loginResult = memberApi.login(accessToken);
+
+        loginResult.getResultActions()
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.accessToken").isNotEmpty());
+
+        return loginResult.getApiResponse().getData().getAccessToken();
+    }
+
+    private void 내_정보_조회(String accessToken) throws Exception {
+        TestApiResult<SuccessSimpleResponse<MemberResponse>> getMeResult = memberApi.getMe(accessToken);
+
+        getMeResult.getResultActions()
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").isNotEmpty());
+
+        Long memberId = getMeResult.getApiResponse().getData().getId();
+        assertThat(memberId).isNotNull();
+    }
+
+    @Test
+    void 같은_카카오_계정으로_두_번째_로그인하는_경우_이전과_같은_accessToken_으로_응답해야함() throws Exception {
+        // given
+        when(kakaoUserService.getUserInfo(any())).thenReturn(OAuthUserInfo.fromKakao("providerUserId"));
+        // when
+        String firstAccessToken = this.로그인("kakaoAccessToken");
+        String secondAccessToken = this.로그인("kakaoAccessToken");
+        // then
+        assertThat(firstAccessToken).isEqualTo(secondAccessToken);
+    }
+}

--- a/src/test/java/com/depromeet/todo/integration/api/MemberApi.java
+++ b/src/test/java/com/depromeet/todo/integration/api/MemberApi.java
@@ -1,0 +1,54 @@
+package com.depromeet.todo.integration.api;
+
+import com.depromeet.todo.presentation.common.SuccessSimpleResponse;
+import com.depromeet.todo.presentation.member.LoginRequest;
+import com.depromeet.todo.presentation.member.LoginResponse;
+import com.depromeet.todo.presentation.member.MemberResponse;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+public class MemberApi {
+    private final MockMvc mockMvc;
+    private final ObjectMapper objectMapper;
+
+    public MemberApi(MockMvc mockMvc, ObjectMapper objectMapper) {
+        this.mockMvc = mockMvc;
+        this.objectMapper = objectMapper;
+    }
+
+    public TestApiResult<SuccessSimpleResponse<LoginResponse>> login(String kakaoAccessToken) throws Exception {
+        LoginRequest loginRequest = new LoginRequest();
+        loginRequest.setAccessToken(kakaoAccessToken);
+
+        ResultActions resultActions = mockMvc.perform(
+                post("/api/members/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(loginRequest))
+        );
+        return new TestApiResult<>(
+                resultActions,
+                new TypeReference<SuccessSimpleResponse<LoginResponse>>() {
+                },
+                objectMapper
+        );
+    }
+
+    public TestApiResult<SuccessSimpleResponse<MemberResponse>> getMe(String accessToken) throws Exception {
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/members/me")
+                        .header("Authorization", "bearer " + accessToken)
+        );
+        return new TestApiResult<>(
+                resultActions,
+                new TypeReference<SuccessSimpleResponse<MemberResponse>>() {
+                },
+                objectMapper
+        );
+    }
+}

--- a/src/test/java/com/depromeet/todo/integration/api/TestApiResult.java
+++ b/src/test/java/com/depromeet/todo/integration/api/TestApiResult.java
@@ -1,0 +1,33 @@
+package com.depromeet.todo.integration.api;
+
+import com.depromeet.todo.presentation.common.ApiResponse;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.io.IOException;
+
+public class TestApiResult<T extends ApiResponse> {
+    private final ResultActions resultActions;
+    private final TypeReference<T> typeReference;
+    private final ObjectMapper objectMapper;
+
+    public TestApiResult(ResultActions resultActions,
+                         TypeReference<T> typeReference,
+                         ObjectMapper objectMapper) {
+        this.resultActions = resultActions;
+        this.typeReference = typeReference;
+        this.objectMapper = objectMapper;
+    }
+
+    public ResultActions getResultActions() {
+        return resultActions;
+    }
+
+    public T getApiResponse() throws IOException {
+        return objectMapper.readValue(
+                resultActions.andReturn().getResponse().getContentAsByteArray(),
+                typeReference
+        );
+    }
+}


### PR DESCRIPTION
resolve #28 
- `GET /api/members/me`
- 자기 자신의 정보를 조회합니다
- 토큰이 없거나 유효하지 않으면 401 로 응답합니다
- 테스트케이스를 추가합니다